### PR TITLE
uid links broken

### DIFF
--- a/collective/sendaspdf/utils.py
+++ b/collective/sendaspdf/utils.py
@@ -315,7 +315,8 @@ def update_relative_url(source, context, embedded_images = True):
 
         path = value.split('/')
 
-        default_replacement = '%s=%s/%s' % (attr, context.absolute_url(), value)
+        portal_path = getMultiAdapter((context, context.REQUEST), name="plone_portal_state").portal().absolute_url()
+        default_replacement = '%s=%s/%s' % (attr, portal_path, value)
         if get_params:
             default_replacement = '%s?%s' % (default_replacement, get_params)
 


### PR DESCRIPTION
The previous one pull request was incomplete.

If you try to generate a pdf on a page with resolve uid links you get broken links (file://)
